### PR TITLE
Hide network selector until connected

### DIFF
--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -51,6 +51,8 @@ export const Header = () => {
 
   console.log(switchChains);
 
+  const [networkConnected, setNetworkConnected] = useState(false);
+
   useEffect(() => {
     if (switchChains.length > 0) {
       setChainData(switchChains.filter(item => [1, 11155111, 137, 10].includes(item.id)));
@@ -115,36 +117,38 @@ export const Header = () => {
         {/* <ul className="hidden lg:flex lg:flex-nowrap menu menu-horizontal px-1 gap-2">{navLinks}</ul> */}
       </div>
       <div className="navbar-end flex-grow mr-4 ">
-        <select
-          className="select select-sm sm:w-fit w-20 mr-2 bg-gray-600 text-white"
-          style={{ borderWidth: 1, borderColor: chain && (chain as any).color }}
-          onChange={event => {
-            const [name, id] = event.target.value.split("|");
-            switchNetwork?.(+id);
-            console.log(name);
-            name === "Ethereum"
-              ? changeTargetNetwork(chains["mainnet"])
-              : name === "Polygon Mumbai"
-              ? changeTargetNetwork(chains["polygonMumbai"])
-              : name === "OP Mainnet"
-              ? changeTargetNetwork(chains["optimism"])
-              : changeTargetNetwork(chains[name.toLowerCase() as keyof typeof chains]);
-          }}
-        >
-          <option disabled>Select network</option>
-          {chainData &&
-            chainData.map(data => (
-              <option
-                key={data.name}
-                value={`${data.name}|${data.id}`}
-                style={{ color: (data as any).color }}
-                selected={selectedNetwork === data.name}
-              >
-                {data.name}
-              </option>
-            ))}
-        </select>
-        <RainbowKitCustomConnectButton />
+        {networkConnected && (
+          <select
+            className="select select-sm sm:w-fit w-20 mr-2 bg-gray-600 text-white"
+            style={{ borderWidth: 1, borderColor: chain && (chain as any).color }}
+            onChange={event => {
+              const [name, id] = event.target.value.split("|");
+              switchNetwork?.(+id);
+              console.log(name);
+              name === "Ethereum"
+                ? changeTargetNetwork(chains["mainnet"])
+                : name === "Polygon Mumbai"
+                ? changeTargetNetwork(chains["polygonMumbai"])
+                : name === "OP Mainnet"
+                ? changeTargetNetwork(chains["optimism"])
+                : changeTargetNetwork(chains[name.toLowerCase() as keyof typeof chains]);
+            }}
+          >
+            <option disabled>Select network</option>
+            {chainData &&
+              chainData.map(data => (
+                <option
+                  key={data.name}
+                  value={`${data.name}|${data.id}`}
+                  style={{ color: (data as any).color }}
+                  selected={selectedNetwork === data.name}
+                >
+                  {data.name}
+                </option>
+              ))}
+          </select>
+        )}
+        <RainbowKitCustomConnectButton setNetworkConnected={setNetworkConnected} />
         <FaucetButton />
       </div>
     </div>

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton.tsx
@@ -19,7 +19,11 @@ import { getBlockExplorerAddressLink, getTargetNetwork } from "~~/utils/scaffold
 /**
  * Custom Wagmi Connect Button (watch balance + custom design)
  */
-export const RainbowKitCustomConnectButton = () => {
+export const RainbowKitCustomConnectButton = ({
+  setNetworkConnected,
+}: {
+  setNetworkConnected: (connected: boolean) => void;
+}) => {
   useAutoConnect();
   const networkColor = useNetworkColor();
   const configuredNetwork = getTargetNetwork();
@@ -39,6 +43,7 @@ export const RainbowKitCustomConnectButton = () => {
           <>
             {(() => {
               if (!connected) {
+                setNetworkConnected(false);
                 return (
                   <button
                     className="bg-gray-600 text-white  btn btn-primary btn-sm"
@@ -51,6 +56,7 @@ export const RainbowKitCustomConnectButton = () => {
               }
 
               if (chain.unsupported || chain.id !== configuredNetwork.id) {
+                setNetworkConnected(true);
                 return (
                   <div className="dropdown dropdown-end ">
                     <label tabIndex={0} className="btn btn-error btn-sm dropdown-toggle gap-1">


### PR DESCRIPTION
## Description

Hide network selector until wallet connected.

Not connected:
![notconnected](https://github.com/BuidlGuidl/Eth-Splitter/assets/98413246/57e76d99-330f-4a53-ac73-ce953e248367)

Connenected:
![connected](https://github.com/BuidlGuidl/Eth-Splitter/assets/98413246/0df08404-572a-41e3-ac34-4a722c2ea5bf)

## Additional Information

- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

#4

Your ENS/address: yanvictorsn.eth