### PR TITLE
Disallow the same ENS/address multiple times

### DIFF
--- a/packages/hardhat/contracts/Splitter.sol
+++ b/packages/hardhat/contracts/Splitter.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
-
+import "hardhat/console.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -31,6 +31,7 @@ contract ETHSplitter is ReentrancyGuard {
   error INSUFFICIENT_SPLIT_AMOUNT();
   error ONLY_OWNER();
   error TRANSFER_FAILED();
+  error DUPLICATE_RECIPIENT();
 
   /**
    * @notice The constructor sets the owner of the contract
@@ -48,11 +49,30 @@ contract ETHSplitter is ReentrancyGuard {
   }
 
   /**
+   * @notice A modifier to check for duplicates and revert before execute a function
+   */
+
+  modifier checkForDuplicates(address payable[] calldata recipients) {
+    uint256 length = recipients.length;
+    for (uint256 i = 0; i < length; i++) {
+      for (uint256 j = i + 1; j < length; j++) {
+        if (recipients[i] == recipients[j]) {
+          revert DUPLICATE_RECIPIENT();
+        }
+      }
+    }
+    _;
+  }
+
+  /**
    * @notice Splits the ETH amongst the given recipients, according to the specified amounts
    * @param recipients The noble recipients of the ETH
    * @param amounts The amounts each recipient shall receive
    */
-  function splitETH(address payable[] calldata recipients, uint256[] calldata amounts) external payable nonReentrant {
+  function splitETH(
+    address payable[] calldata recipients,
+    uint256[] calldata amounts
+  ) external payable nonReentrant checkForDuplicates(recipients) {
     uint256 remainingAmount = _splitETH(recipients, amounts, msg.value);
     emit EthSplit(msg.sender, msg.value, recipients, amounts);
 
@@ -62,12 +82,17 @@ contract ETHSplitter is ReentrancyGuard {
     }
   }
 
+  event LogMessage(string message);
+
   /**
    * @notice Splits the ETH equally amongst the given recipients
-   * @dev The contract gracefully adds any leftover dust to the amount to be received by the first recipient in the input array. 
+   * @dev The contract gracefully adds any leftover dust to the amount to be received by the first recipient in the input array.
    * @param recipients The noble recipients of the ETH
    */
-  function splitEqualETH(address payable[] calldata recipients) external payable nonReentrant {
+
+  function splitEqualETH(
+    address payable[] calldata recipients
+  ) external payable nonReentrant checkForDuplicates(recipients) {
     uint256 totalAmount = msg.value;
     uint256 rLength = recipients.length;
     uint256 equalAmount = totalAmount / rLength;
@@ -75,7 +100,7 @@ contract ETHSplitter is ReentrancyGuard {
 
     if (rLength > 25 || rLength < 2) revert INSUFFICIENT_RECIPIENT_COUNT();
 
-    for (uint256 i = 0; i < rLength;) {
+    for (uint256 i = 0; i < rLength; ) {
       if (recipients[i] == address(0)) revert INVALID_RECIPIENT();
       uint256 amountToSend = equalAmount;
       if (i == 0) {
@@ -97,7 +122,11 @@ contract ETHSplitter is ReentrancyGuard {
    * @param recipients The noble recipients of the ERC20 tokens
    * @param amounts The amounts each recipient shall receive
    */
-  function splitERC20(IERC20 token, address payable[] calldata recipients, uint256[] calldata amounts) external nonReentrant {
+  function splitERC20(
+    IERC20 token,
+    address payable[] calldata recipients,
+    uint256[] calldata amounts
+  ) external nonReentrant checkForDuplicates(recipients) {
     _transferTokensFromSenderToRecipients(token, recipients, amounts);
     emit Erc20Split(msg.sender, recipients, amounts);
   }
@@ -108,7 +137,11 @@ contract ETHSplitter is ReentrancyGuard {
    * @param recipients The noble recipients of the ERC20 tokens
    * @param totalAmount The total amount to be shared
    */
-  function splitEqualERC20(IERC20 token, address payable[] calldata recipients, uint256 totalAmount) external nonReentrant {
+  function splitEqualERC20(
+    IERC20 token,
+    address payable[] calldata recipients,
+    uint256 totalAmount
+  ) external nonReentrant checkForDuplicates(recipients) {
     uint256 rLength = recipients.length;
 
     if (rLength > 25 || rLength < 2) revert INSUFFICIENT_RECIPIENT_COUNT();
@@ -116,7 +149,7 @@ contract ETHSplitter is ReentrancyGuard {
     uint256 equalAmount = totalAmount / rLength;
 
     uint256 remainingAmount = totalAmount % rLength;
-    for (uint256 i = 0; i < rLength;) {
+    for (uint256 i = 0; i < rLength; ) {
       if (recipients[i] == address(0)) revert INVALID_RECIPIENT();
 
       uint256 amountToSend = equalAmount;
@@ -146,11 +179,11 @@ contract ETHSplitter is ReentrancyGuard {
   ) internal returns (uint256 remainingAmount) {
     uint256 length = recipients.length;
     if (length != amounts.length) revert INVALID_INPUT();
-    
+
     if (length > 25 || length < 2) revert INSUFFICIENT_RECIPIENT_COUNT();
 
     uint256 totalAmount = 0;
-    for (uint256 i = 0; i < length;) {
+    for (uint256 i = 0; i < length; ) {
       if (recipients[i] == address(0)) revert INVALID_RECIPIENT();
       if (amounts[i] == 0) revert INSUFFICIENT_SPLIT_AMOUNT();
 
@@ -182,7 +215,7 @@ contract ETHSplitter is ReentrancyGuard {
     if (length != amounts.length) revert INVALID_INPUT();
     if (length > 25 || length < 2) revert INSUFFICIENT_RECIPIENT_COUNT();
 
-    for (uint256 i = 0; i < length;) {
+    for (uint256 i = 0; i < length; ) {
       if (recipients[i] == address(0)) revert INVALID_RECIPIENT();
       if (amounts[i] == 0) revert INSUFFICIENT_SPLIT_AMOUNT();
 
@@ -192,7 +225,6 @@ contract ETHSplitter is ReentrancyGuard {
       }
     }
   }
-
 
   /**
    * @notice Withdraws the remaining ETH or ERC20 tokens to the owner's address

--- a/packages/hardhat/contracts/Splitter.sol
+++ b/packages/hardhat/contracts/Splitter.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
-import "hardhat/console.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -81,8 +80,6 @@ contract ETHSplitter is ReentrancyGuard {
       if (!success) revert TRANSFER_FAILED();
     }
   }
-
-  event LogMessage(string message);
 
   /**
    * @notice Splits the ETH equally amongst the given recipients

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -22,8 +22,6 @@ export const Header = () => {
     scaffoldConfig.targetNetwork = newNetwork;
   }
 
-  console.log(switchChains);
-
   const [networkConnected, setNetworkConnected] = useState(false);
 
   useEffect(() => {
@@ -60,7 +58,6 @@ export const Header = () => {
             onChange={event => {
               const [name, id] = event.target.value.split("|");
               switchNetwork?.(+id);
-              console.log(name);
               name === "Ethereum"
                 ? changeTargetNetwork(chains["mainnet"])
                 : name === "Polygon Mumbai"

--- a/packages/nextjs/components/splitter-ui/EqualUi.tsx
+++ b/packages/nextjs/components/splitter-ui/EqualUi.tsx
@@ -27,8 +27,6 @@ const EqualUi = ({ splitItem, account, splitterContract }: UiJsxProps) => {
         if (state.length > 0 && action.payload > 0) {
           const uniqueAddress = action.payload.filter((address: string) => !state.includes(address));
           setValue("");
-          console.log(uniqueAddress);
-          console.log(state);
           return [...state, ...uniqueAddress];
         } else {
           setValue("");
@@ -94,10 +92,6 @@ const EqualUi = ({ splitItem, account, splitterContract }: UiJsxProps) => {
     return addresses;
   }
 
-  // function removeDuplicate() {
-
-  // }
-
   async function addMultipleAddress(inputValue: string) {
     const addresses: string[] = formatedAddresses(inputValue);
 
@@ -116,10 +110,8 @@ const EqualUi = ({ splitItem, account, splitterContract }: UiJsxProps) => {
         const index = uniqueValidadeAddresses.findIndex(address => address === ensResult.ensName);
         uniqueValidadeAddresses[index] = ensResult.address;
       });
-      console.log(uniqueAddresses, "Aqui");
       dispatch({ type: "addWallets", payload: uniqueValidadeAddresses });
     }
-    console.log(uniqueAddresses, "Here");
     dispatch({ type: "addWallets", payload: uniqueValidadeAddresses });
   }
 

--- a/packages/nextjs/components/splitter-ui/EqualUi.tsx
+++ b/packages/nextjs/components/splitter-ui/EqualUi.tsx
@@ -27,10 +27,13 @@ const EqualUi = ({ splitItem, account, splitterContract }: UiJsxProps) => {
         if (state.length > 0 && action.payload > 0) {
           const uniqueAddress = action.payload.filter((address: string) => !state.includes(address));
           setValue("");
+          console.log(uniqueAddress);
+          console.log(state);
           return [...state, ...uniqueAddress];
         } else {
           setValue("");
-          return [...action.payload];
+          const uniqueAddress = removeDuplicates(action.payload);
+          return [...uniqueAddress];
         }
 
       case "removeWallets":
@@ -41,6 +44,17 @@ const EqualUi = ({ splitItem, account, splitterContract }: UiJsxProps) => {
         return state;
     }
   };
+
+  function removeDuplicates(walletsArray: string[]) {
+    const uniqueAddresses: string[] = [];
+
+    for (const address of walletsArray) {
+      if (!uniqueAddresses.includes(address)) {
+        uniqueAddresses.push(address);
+      }
+    }
+    return uniqueAddresses;
+  }
 
   const [wallets, dispatch] = useReducer(walletsReducer, []);
 
@@ -80,6 +94,10 @@ const EqualUi = ({ splitItem, account, splitterContract }: UiJsxProps) => {
     return addresses;
   }
 
+  // function removeDuplicate() {
+
+  // }
+
   async function addMultipleAddress(inputValue: string) {
     const addresses: string[] = formatedAddresses(inputValue);
 
@@ -98,14 +116,15 @@ const EqualUi = ({ splitItem, account, splitterContract }: UiJsxProps) => {
         const index = uniqueValidadeAddresses.findIndex(address => address === ensResult.ensName);
         uniqueValidadeAddresses[index] = ensResult.address;
       });
+      console.log(uniqueAddresses, "Aqui");
       dispatch({ type: "addWallets", payload: uniqueValidadeAddresses });
     }
+    console.log(uniqueAddresses, "Here");
     dispatch({ type: "addWallets", payload: uniqueValidadeAddresses });
   }
 
   const removeWalletField = (index: number) => {
     dispatch({ type: "removeWallets", payload: index });
-    console.log(wallets);
   };
 
   const { writeAsync: splitEqualETH } = useScaffoldContractWrite({

--- a/packages/nextjs/components/splitter-ui/UnEqualUi.tsx
+++ b/packages/nextjs/components/splitter-ui/UnEqualUi.tsx
@@ -21,7 +21,6 @@ const UnEqualUi = ({ splitItem, account, splitterContract }: UiJsxProps) => {
 
     let uniqueAddresses = [...new Set([...addresses])];
     uniqueAddresses = [...new Set([...wallets.filter(validateAddress), ...uniqueAddresses])];
-    console.log(value);
     setWallets(uniqueAddresses);
   }
 

--- a/packages/nextjs/components/splitter-ui/UnEqualUi.tsx
+++ b/packages/nextjs/components/splitter-ui/UnEqualUi.tsx
@@ -21,6 +21,7 @@ const UnEqualUi = ({ splitItem, account, splitterContract }: UiJsxProps) => {
 
     let uniqueAddresses = [...new Set([...addresses])];
     uniqueAddresses = [...new Set([...wallets.filter(validateAddress), ...uniqueAddresses])];
+    console.log(value);
     setWallets(uniqueAddresses);
   }
 
@@ -44,7 +45,12 @@ const UnEqualUi = ({ splitItem, account, splitterContract }: UiJsxProps) => {
   const updateWallet = (value: string, index: number) => {
     if (value.length <= 42) {
       const newWallets = [...wallets];
-      newWallets[index] = value;
+      if (newWallets.length > 1 && newWallets.includes(value)) {
+        return;
+      } else {
+        newWallets[index] = value;
+        setWallets(newWallets);
+      }
       setWallets(newWallets);
     }
 


### PR DESCRIPTION
## Description

Disallow the same ENS/address multiple times checking in smart contract and in front end for duplicates.

Smart Contract:

https://github.com/BuidlGuidl/Eth-Splitter/assets/98413246/01c0aa15-ae13-490d-8a59-a3bc32a9779e

Front End:

https://github.com/BuidlGuidl/Eth-Splitter/assets/98413246/6a3193d1-47e6-4c07-acc2-cf3c3033bd60


## Additional Information

- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)
- [x]  Check duplicates with two loops in smart contract - O(n²)
- [x]  Check duplicates in both Unequal and Equal front end.

## Related Issues
Closes #14 

Your ENS/address: yanvictorsn.eth