### PR TITLE
Fix decimal issue if 0 is not entered first

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Input/EtherInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/EtherInput.tsx
@@ -83,6 +83,9 @@ export const EtherInput = ({
   }, [nativeCurrencyPrice, transitoryDisplayValue, usdMode, usdGenMode, value]);
 
   const handleChangeNumber = (newValue: string) => {
+    if (newValue.startsWith(".")) {
+      newValue = `0${newValue}`;
+    }
     if (newValue && !SIGNED_NUMBER_REGEX.test(newValue)) {
       return;
     }


### PR DESCRIPTION
## Description

Fixed decimal issue if 0 is not entered first only in EtherInput.

## Additional Information

- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues
Closes #51

Your ENS/address: yanvictorsn.eth