### PR TITLE
Added a transaction success display after a completed split

### DIFF
--- a/packages/nextjs/app/split-review/_components/TransactionSuccess.tsx
+++ b/packages/nextjs/app/split-review/_components/TransactionSuccess.tsx
@@ -1,0 +1,169 @@
+// This file should be saved as: packages/nextjs/components/TransactionSuccess.tsx
+import React from "react";
+import { useRouter } from "next/navigation";
+import { motion } from "framer-motion";
+import { CheckCircle, ExternalLink, Home, Plus, Users } from "lucide-react";
+import { Address } from "~~/components/scaffold-eth";
+import { useTargetNetwork } from "~~/hooks/scaffold-eth";
+import { getBlockExplorerTxLink } from "~~/utils/scaffold-eth";
+
+interface Recipient {
+  id: string;
+  address: string;
+  amount: string;
+  percentage?: number;
+  label?: string;
+  ensName?: string;
+}
+
+interface TransactionSuccessProps {
+  transactionHash: string;
+  recipients: Recipient[];
+  totalAmount: string;
+  token: {
+    address: string;
+    symbol: string;
+    name: string;
+    decimals: number;
+  };
+  splitMode: "EQUAL" | "UNEQUAL";
+}
+
+export const TransactionSuccess: React.FC<TransactionSuccessProps> = ({
+  transactionHash,
+  recipients,
+  totalAmount,
+  token,
+  splitMode,
+}) => {
+  const router = useRouter();
+  const { targetNetwork } = useTargetNetwork();
+  const blockExplorerLink = getBlockExplorerTxLink(targetNetwork.id, transactionHash);
+
+  const handleNewSplit = () => {
+    localStorage.removeItem("pendingSplit");
+    router.push("/split");
+  };
+
+  const handleViewHistory = () => {
+    localStorage.removeItem("pendingSplit");
+    router.push("/history");
+  };
+
+  const handleGoHome = () => {
+    localStorage.removeItem("pendingSplit");
+    router.push("/");
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
+    >
+      <motion.div
+        initial={{ scale: 0.9, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        transition={{ delay: 0.1 }}
+        className="bg-base-100 rounded-3xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-hidden"
+      >
+        {/* Success Header */}
+        <div className="bg-gradient-to-r from-success/20 to-primary/20 p-8 text-center">
+          <motion.div
+            initial={{ scale: 0 }}
+            animate={{ scale: 1 }}
+            transition={{ delay: 0.3, type: "spring", stiffness: 200 }}
+            className="inline-flex items-center justify-center w-20 h-20 bg-success rounded-full mb-4"
+          >
+            <CheckCircle className="w-12 h-12 text-success-content" />
+          </motion.div>
+          <h2 className="text-3xl font-bold mb-2">Split Successful!</h2>
+          <p className="text-base-content/80">Your tokens have been distributed successfully</p>
+        </div>
+
+        {/* Transaction Details */}
+        <div className="p-6 space-y-6 max-h-[50vh] overflow-y-auto">
+          {/* Amount Summary */}
+          <div className="bg-base-200 rounded-2xl p-4">
+            <div className="text-center">
+              <p className="text-sm text-base-content/60 mb-1">Total Amount Split</p>
+              <p className="text-2xl font-bold">
+                {totalAmount} {token.symbol}
+              </p>
+              <p className="text-sm text-base-content/60 mt-1">
+                Distributed to {recipients.length} recipient{recipients.length > 1 ? "s" : ""}
+              </p>
+            </div>
+          </div>
+
+          {/* Recipients Summary */}
+          <div className="space-y-2">
+            <h3 className="text-sm font-medium text-base-content/60">Recipients</h3>
+            <div className="bg-base-200 rounded-xl p-3 max-h-32 overflow-y-auto">
+              <div className="space-y-2">
+                {recipients.slice(0, 3).map(recipient => (
+                  <div key={recipient.id} className="flex justify-between items-center text-sm">
+                    <div className="flex items-center gap-2">
+                      <Address address={recipient.address} format="short" />
+                      {recipient.label && <span className="text-xs text-base-content/60">({recipient.label})</span>}
+                    </div>
+                    <span className="font-medium">
+                      {splitMode === "EQUAL"
+                        ? (parseFloat(totalAmount) / recipients.length).toFixed(4)
+                        : recipient.amount}{" "}
+                      {token.symbol}
+                    </span>
+                  </div>
+                ))}
+                {recipients.length > 3 && (
+                  <div className="text-center text-sm text-base-content/60 pt-1">
+                    and {recipients.length - 3} more...
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Transaction Hash */}
+          <div className="bg-base-200 rounded-xl p-4">
+            <div className="flex justify-between items-center">
+              <div>
+                <p className="text-xs text-base-content/60 mb-1">Transaction Hash</p>
+                <p className="font-mono text-sm break-all">
+                  {transactionHash.slice(0, 10)}...{transactionHash.slice(-8)}
+                </p>
+              </div>
+              <a
+                href={blockExplorerLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-sm btn-ghost gap-2"
+              >
+                <ExternalLink className="w-4 h-4" />
+                View
+              </a>
+            </div>
+          </div>
+        </div>
+
+        {/* Action Buttons */}
+        <div className="p-6 bg-base-200/50 border-t border-base-300">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <button onClick={handleNewSplit} className="btn btn-primary gap-2">
+              <Plus className="w-4 h-4" />
+              New Split
+            </button>
+            <button onClick={handleViewHistory} className="btn btn-outline gap-2">
+              <Users className="w-4 h-4" />
+              View History
+            </button>
+            <button onClick={handleGoHome} className="btn btn-ghost gap-2">
+              <Home className="w-4 h-4" />
+              Home
+            </button>
+          </div>
+        </div>
+      </motion.div>
+    </motion.div>
+  );
+};

--- a/packages/nextjs/app/split-review/_components/TransactionSuccess.tsx
+++ b/packages/nextjs/app/split-review/_components/TransactionSuccess.tsx
@@ -1,4 +1,3 @@
-// This file should be saved as: packages/nextjs/components/TransactionSuccess.tsx
 import React from "react";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
@@ -67,7 +66,6 @@ export const TransactionSuccess: React.FC<TransactionSuccessProps> = ({
         transition={{ delay: 0.1 }}
         className="bg-base-100 rounded-3xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-hidden"
       >
-        {/* Success Header */}
         <div className="bg-gradient-to-r from-success/20 to-primary/20 p-8 text-center">
           <motion.div
             initial={{ scale: 0 }}
@@ -81,9 +79,7 @@ export const TransactionSuccess: React.FC<TransactionSuccessProps> = ({
           <p className="text-base-content/80">Your tokens have been distributed successfully</p>
         </div>
 
-        {/* Transaction Details */}
         <div className="p-6 space-y-6 max-h-[50vh] overflow-y-auto">
-          {/* Amount Summary */}
           <div className="bg-base-200 rounded-2xl p-4">
             <div className="text-center">
               <p className="text-sm text-base-content/60 mb-1">Total Amount Split</p>
@@ -96,7 +92,6 @@ export const TransactionSuccess: React.FC<TransactionSuccessProps> = ({
             </div>
           </div>
 
-          {/* Recipients Summary */}
           <div className="space-y-2">
             <h3 className="text-sm font-medium text-base-content/60">Recipients</h3>
             <div className="bg-base-200 rounded-xl p-3 max-h-32 overflow-y-auto">
@@ -124,7 +119,6 @@ export const TransactionSuccess: React.FC<TransactionSuccessProps> = ({
             </div>
           </div>
 
-          {/* Transaction Hash */}
           <div className="bg-base-200 rounded-xl p-4">
             <div className="flex justify-between items-center">
               <div>
@@ -146,7 +140,6 @@ export const TransactionSuccess: React.FC<TransactionSuccessProps> = ({
           </div>
         </div>
 
-        {/* Action Buttons */}
         <div className="p-6 bg-base-200/50 border-t border-base-300">
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
             <button onClick={handleNewSplit} className="btn btn-primary gap-2">

--- a/packages/nextjs/app/split-review/page.tsx
+++ b/packages/nextjs/app/split-review/page.tsx
@@ -248,9 +248,7 @@ export default function SplitReviewPage() {
       }
 
       if (txHash) {
-        notification.success("Split executed successfully!");
 
-        // Show success modal instead of redirecting
         setTransactionSuccess({
           hash: txHash,
           recipients: splitData.recipients,
@@ -293,7 +291,6 @@ export default function SplitReviewPage() {
     : BigInt(0);
   const hasSufficientAllowance = tokenAllowance && tokenAllowance >= totalAmountBigInt;
 
-  // Show transaction success modal if transaction completed
   if (transactionSuccess) {
     return (
       <TransactionSuccess

--- a/packages/nextjs/app/split-review/page.tsx
+++ b/packages/nextjs/app/split-review/page.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { TransactionSuccess } from "./_components/TransactionSuccess";
 import { AlertCircle, ArrowLeft, CheckCircle } from "lucide-react";
 import { formatEther, formatGwei, formatUnits, parseEther, parseUnits } from "viem";
 import { useAccount, useBalance, useFeeData, usePublicClient } from "wagmi";
@@ -40,6 +41,13 @@ export default function SplitReviewPage() {
   const [gasEstimationError, setGasEstimationError] = useState<string | null>(null);
   const [isExecuting, setIsExecuting] = useState(false);
   const [isApproving, setIsApproving] = useState(false);
+  const [transactionSuccess, setTransactionSuccess] = useState<{
+    hash: string;
+    recipients: Recipient[];
+    totalAmount: string;
+    token: { address: string; symbol: string; name: string; decimals: number };
+    splitMode: "EQUAL" | "UNEQUAL";
+  } | null>(null);
   const { targetNetwork } = useTargetNetwork();
 
   const nativeCurrency = targetNetwork.nativeCurrency;
@@ -73,45 +81,48 @@ export default function SplitReviewPage() {
       router.push("/split");
       return;
     }
-    setSplitData(JSON.parse(data));
+
+    try {
+      const parsed = JSON.parse(data);
+      setSplitData(parsed);
+    } catch (error) {
+      console.error("Error parsing split data:", error);
+      notification.error("Invalid split data");
+      router.push("/split");
+    }
   }, [router]);
 
   const estimateGas = useCallback(async () => {
-    if (!splitData || !deployedContractInfo || !publicClient || !connectedAddress) {
-      return;
-    }
+    if (!splitData || !publicClient || !connectedAddress || !deployedContractInfo) return;
 
     setIsEstimatingGas(true);
     setGasEstimationError(null);
 
     try {
-      let estimatedGasResult = BigInt(0);
-
       const recipients = splitData.recipients.map(r => r.address as `0x${string}`);
+      let estimatedGas: bigint;
 
       if (splitData.token?.address === "ETH") {
         if (splitData.splitMode === "EQUAL") {
           const totalValue = parseEther(splitData.totalAmount);
-
-          estimatedGasResult = await publicClient.estimateContractGas({
+          estimatedGas = await publicClient.estimateContractGas({
             address: deployedContractInfo.address as `0x${string}`,
             abi: deployedContractInfo.abi,
             functionName: "splitEqualETH",
             args: [recipients],
-            value: totalValue,
             account: connectedAddress,
+            value: totalValue,
           });
         } else {
           const amounts = splitData.recipients.map(r => parseEther(r.amount));
           const totalValue = amounts.reduce((sum, amount) => sum + amount, BigInt(0));
-
-          estimatedGasResult = await publicClient.estimateContractGas({
+          estimatedGas = await publicClient.estimateContractGas({
             address: deployedContractInfo.address as `0x${string}`,
             abi: deployedContractInfo.abi,
             functionName: "splitETH",
             args: [recipients, amounts],
-            value: totalValue,
             account: connectedAddress,
+            value: totalValue,
           });
         }
       } else {
@@ -120,7 +131,7 @@ export default function SplitReviewPage() {
         const totalAmount = parseUnits(splitData.totalAmount, decimals);
 
         if (splitData.splitMode === "EQUAL") {
-          estimatedGasResult = await publicClient.estimateContractGas({
+          estimatedGas = await publicClient.estimateContractGas({
             address: deployedContractInfo.address as `0x${string}`,
             abi: deployedContractInfo.abi,
             functionName: "splitEqualERC20",
@@ -129,8 +140,7 @@ export default function SplitReviewPage() {
           });
         } else {
           const amounts = splitData.recipients.map(r => parseUnits(r.amount, decimals));
-
-          estimatedGasResult = await publicClient.estimateContractGas({
+          estimatedGas = await publicClient.estimateContractGas({
             address: deployedContractInfo.address as `0x${string}`,
             abi: deployedContractInfo.abi,
             functionName: "splitERC20",
@@ -140,27 +150,21 @@ export default function SplitReviewPage() {
         }
       }
 
-      const gasWithBuffer = (estimatedGasResult * BigInt(110)) / BigInt(100);
-      setEstimatedGas(gasWithBuffer);
-      setGasEstimationError(null);
+      const buffer = (estimatedGas * BigInt(120)) / BigInt(100);
+      setEstimatedGas(buffer);
     } catch (error) {
-      console.error("Gas estimation error:", error);
-      setGasEstimationError("Unable to estimate gas accurately");
-
-      const baseGas = BigInt(50000);
-      const perRecipientGas = BigInt(30000);
-      const fallbackGas = baseGas + perRecipientGas * BigInt(splitData.recipients.length);
+      console.error("Error estimating gas:", error);
+      setGasEstimationError("Could not estimate gas. The transaction may fail.");
+      const fallbackGas = BigInt(300000);
       setEstimatedGas(fallbackGas);
     } finally {
       setIsEstimatingGas(false);
     }
-  }, [splitData, deployedContractInfo, publicClient, connectedAddress]);
+  }, [splitData, publicClient, connectedAddress, deployedContractInfo]);
 
   useEffect(() => {
-    if (splitData && deployedContractInfo && publicClient && connectedAddress) {
-      estimateGas();
-    }
-  }, [splitData, deployedContractInfo, publicClient, connectedAddress, estimateGas]);
+    estimateGas();
+  }, [estimateGas]);
 
   const handleApproveToken = async () => {
     if (!splitData || !splitData.token || splitData.token.address === "ETH") {
@@ -196,12 +200,13 @@ export default function SplitReviewPage() {
 
     try {
       const recipients = splitData.recipients.map(r => r.address as `0x${string}`);
+      let txHash: string | undefined;
 
       if (splitData.token.address === "ETH") {
         if (splitData.splitMode === "EQUAL") {
           const totalValue = parseEther(splitData.totalAmount);
 
-          await writeSplitter({
+          txHash = await writeSplitter({
             functionName: "splitEqualETH",
             args: [recipients],
             value: totalValue,
@@ -210,7 +215,7 @@ export default function SplitReviewPage() {
           const amounts = splitData.recipients.map(r => parseEther(r.amount));
           const totalValue = amounts.reduce((sum, amount) => sum + amount, BigInt(0));
 
-          await writeSplitter({
+          txHash = await writeSplitter({
             functionName: "splitETH",
             args: [recipients, amounts],
             value: totalValue,
@@ -228,23 +233,32 @@ export default function SplitReviewPage() {
         }
 
         if (splitData.splitMode === "EQUAL") {
-          await writeSplitter({
+          txHash = await writeSplitter({
             functionName: "splitEqualERC20",
             args: [tokenAddress, recipients, totalAmount],
           });
         } else {
           const amounts = splitData.recipients.map(r => parseUnits(r.amount, decimals));
 
-          await writeSplitter({
+          txHash = await writeSplitter({
             functionName: "splitERC20",
             args: [tokenAddress, recipients, amounts],
           });
         }
       }
 
-      notification.success("Split executed successfully!");
-      localStorage.removeItem("pendingSplit");
-      router.push("/split");
+      if (txHash) {
+        notification.success("Split executed successfully!");
+
+        // Show success modal instead of redirecting
+        setTransactionSuccess({
+          hash: txHash,
+          recipients: splitData.recipients,
+          totalAmount: splitData.totalAmount,
+          token: splitData.token,
+          splitMode: splitData.splitMode,
+        });
+      }
     } catch (error) {
       console.error("Error executing split:", error);
       notification.error("Failed to execute split");
@@ -278,6 +292,19 @@ export default function SplitReviewPage() {
     ? parseUnits(splitData.totalAmount, splitData.token?.decimals || 18)
     : BigInt(0);
   const hasSufficientAllowance = tokenAllowance && tokenAllowance >= totalAmountBigInt;
+
+  // Show transaction success modal if transaction completed
+  if (transactionSuccess) {
+    return (
+      <TransactionSuccess
+        transactionHash={transactionSuccess.hash}
+        recipients={transactionSuccess.recipients}
+        totalAmount={transactionSuccess.totalAmount}
+        token={transactionSuccess.token}
+        splitMode={transactionSuccess.splitMode}
+      />
+    );
+  }
 
   if (!splitData || !splitData.token) {
     return (
@@ -493,12 +520,21 @@ export default function SplitReviewPage() {
                 <div className="mt-6 p-4 bg-base-200 rounded-xl">
                   <p className="text-xs text-base-content/60 mb-1">Your {splitData.token.symbol} Balance</p>
                   <p className="text-sm font-medium">
-                    {tokenBalance ? formatUnits(tokenBalance as bigint, splitData.token.decimals) : "0"}{" "}
+                    {tokenBalance
+                      ? formatUnits(
+                          typeof tokenBalance === "object" && "value" in tokenBalance
+                            ? tokenBalance.value
+                            : tokenBalance,
+                          splitData.token.decimals || 18,
+                        )
+                      : "0"}{" "}
                     {splitData.token.symbol}
                   </p>
-                  {parseUnits(splitData.totalAmount, splitData.token.decimals) > (tokenBalance as bigint) && (
-                    <p className="text-xs text-error mt-2">Insufficient balance</p>
-                  )}
+                  {tokenBalance &&
+                    typeof tokenBalance === "object" &&
+                    parseUnits(splitData.totalAmount, splitData.token.decimals || 18) > tokenBalance.value && (
+                      <p className="text-xs text-error mt-2">Insufficient balance</p>
+                    )}
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Description

This is based on the request here https://github.com/BuidlGuidl/Eth-Splitter/pull/82#pullrequestreview-3160174718

Now after a complete transction a success modal opens showing the user the details of the successful transction and buttons to view the transction in the block explorer, go back home, view history or start a new split


<img width="1799" height="941" alt="Screenshot at Sep 15 18-10-57" src="https://github.com/user-attachments/assets/c44cb079-db6a-4ef7-9e69-55e5183a29ce" />
