### PR TITLE
Added feature to repeat transaction ftom history page

### DIFF
--- a/packages/nextjs/app/history/_components/HistoryCard.tsx
+++ b/packages/nextjs/app/history/_components/HistoryCard.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import { ArrowRight, Clock, Coins, Repeat, Users } from "lucide-react";
 import { formatUnits } from "viem";
@@ -12,37 +11,20 @@ interface HistoryCardProps {
   split: SplitHistoryItem;
   onClick: () => void;
   delay?: number;
+  handleRepeat: (
+    split: SplitHistoryItem,
+    isEqual: boolean,
+    isErc20: boolean,
+    onSuccess?: () => void,
+    e?: React.MouseEvent,
+  ) => void;
 }
 
-export const HistoryCard: React.FC<HistoryCardProps> = ({ split, onClick, delay = 0 }) => {
+export const HistoryCard: React.FC<HistoryCardProps> = ({ split, onClick, delay = 0, handleRepeat }) => {
   const { targetNetwork } = useTargetNetwork();
-  const router = useRouter();
 
   const isErc20 = isErc20Transaction(split);
   const isEqual = isEqualSplit(split);
-
-  const handleRepeat = (e: React.MouseEvent) => {
-    e.stopPropagation();
-
-    const params = new URLSearchParams();
-
-    params.append("mode", isEqual ? "EQUAL" : "UNEQUAL");
-
-    if (isErc20) {
-      params.append("token", split.token!);
-      params.append("tokenSymbol", split.tokenSymbol!);
-      params.append("tokenDecimals", split.tokenDecimals!.toString());
-    } else {
-      params.append("token", "ETH");
-    }
-
-    split.recipients.forEach((recipient, index) => {
-      params.append(`recipient_${index}`, recipient);
-    });
-    params.append("recipientCount", split.recipientCount.toString());
-
-    router.push(`/split?${params.toString()}`);
-  };
 
   const formatAmount = (amount: string, decimals = 18) => {
     const formatted = formatUnits(BigInt(amount), decimals);
@@ -124,6 +106,10 @@ export const HistoryCard: React.FC<HistoryCardProps> = ({ split, onClick, delay 
     }
   };
 
+  function _(): void {
+    throw new Error("Function not implemented.");
+  }
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
@@ -181,7 +167,11 @@ export const HistoryCard: React.FC<HistoryCardProps> = ({ split, onClick, delay 
         </div>
 
         <div className="card-actions justify-end">
-          <button className="btn btn-ghost btn-sm gap-1" onClick={handleRepeat} title="Repeat this split">
+          <button
+            className="btn btn-ghost btn-sm gap-1"
+            onClick={e => handleRepeat(split, isEqual, isErc20, _, e)}
+            title="Repeat this split"
+          >
             <Repeat className="w-4 h-4" />
             Repeat
           </button>

--- a/packages/nextjs/app/history/_components/HistoryCard.tsx
+++ b/packages/nextjs/app/history/_components/HistoryCard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
+import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
-import { ArrowRight, Clock, Coins, Users } from "lucide-react";
+import { ArrowRight, Clock, Coins, Repeat, Users } from "lucide-react";
 import { formatUnits } from "viem";
 import { Address } from "~~/components/scaffold-eth";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth";
@@ -15,9 +16,33 @@ interface HistoryCardProps {
 
 export const HistoryCard: React.FC<HistoryCardProps> = ({ split, onClick, delay = 0 }) => {
   const { targetNetwork } = useTargetNetwork();
+  const router = useRouter();
 
   const isErc20 = isErc20Transaction(split);
   const isEqual = isEqualSplit(split);
+
+  const handleRepeat = (e: React.MouseEvent) => {
+    e.stopPropagation();
+
+    const params = new URLSearchParams();
+
+    params.append("mode", isEqual ? "EQUAL" : "UNEQUAL");
+
+    if (isErc20) {
+      params.append("token", split.token!);
+      params.append("tokenSymbol", split.tokenSymbol!);
+      params.append("tokenDecimals", split.tokenDecimals!.toString());
+    } else {
+      params.append("token", "ETH");
+    }
+
+    split.recipients.forEach((recipient, index) => {
+      params.append(`recipient_${index}`, recipient);
+    });
+    params.append("recipientCount", split.recipientCount.toString());
+
+    router.push(`/split?${params.toString()}`);
+  };
 
   const formatAmount = (amount: string, decimals = 18) => {
     const formatted = formatUnits(BigInt(amount), decimals);
@@ -156,6 +181,10 @@ export const HistoryCard: React.FC<HistoryCardProps> = ({ split, onClick, delay 
         </div>
 
         <div className="card-actions justify-end">
+          <button className="btn btn-ghost btn-sm gap-1" onClick={handleRepeat} title="Repeat this split">
+            <Repeat className="w-4 h-4" />
+            Repeat
+          </button>
           <button className="btn btn-ghost btn-sm gap-1">
             View Details
             <ArrowRight className="w-4 h-4" />

--- a/packages/nextjs/app/history/_components/HistoryDetailsDrawer.tsx
+++ b/packages/nextjs/app/history/_components/HistoryDetailsDrawer.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useRouter } from "next/navigation";
 import { AnimatePresence, motion } from "framer-motion";
 import { CheckCircle, Coins, Copy, ExternalLink, Hash, Layers, Repeat, Users, X } from "lucide-react";
 import { formatUnits } from "viem";
@@ -14,11 +13,17 @@ interface HistoryDetailsDrawerProps {
   split: SplitHistoryItem | null;
   isOpen: boolean;
   onClose: () => void;
+  handleRepeat: (
+    split: SplitHistoryItem,
+    isEqual: boolean,
+    isErc20: boolean,
+    onSuccess?: () => void,
+    e?: React.MouseEvent,
+  ) => void;
 }
 
-export const HistoryDetailsDrawer: React.FC<HistoryDetailsDrawerProps> = ({ split, isOpen, onClose }) => {
+export const HistoryDetailsDrawer: React.FC<HistoryDetailsDrawerProps> = ({ split, isOpen, onClose, handleRepeat }) => {
   const targetNetworks = getTargetNetworks();
-  const router = useRouter();
 
   const splitNetwork = targetNetworks.find(network => network.id == split?.chainId);
   const { copyToClipboard, isCopiedToClipboard } = useCopyToClipboard();
@@ -27,31 +32,6 @@ export const HistoryDetailsDrawer: React.FC<HistoryDetailsDrawerProps> = ({ spli
 
   const isErc20 = isErc20Transaction(split);
   const isEqual = isEqualSplit(split);
-
-  const handleRepeat = () => {
-    if (!split) return;
-
-    const params = new URLSearchParams();
-    const isEqual = isEqualSplit(split);
-
-    params.append("mode", isEqual ? "EQUAL" : "UNEQUAL");
-
-    if (isErc20Transaction(split)) {
-      params.append("token", split.token!);
-      params.append("tokenSymbol", split.tokenSymbol!);
-      params.append("tokenDecimals", split.tokenDecimals!.toString());
-    } else {
-      params.append("token", "ETH");
-    }
-
-    split.recipients.forEach((recipient, index) => {
-      params.append(`recipient_${index}`, recipient);
-    });
-    params.append("recipientCount", split.recipientCount.toString());
-
-    router.push(`/split?${params.toString()}`);
-    onClose();
-  };
 
   const formatAmount = (amount: string, decimals = 18) => {
     const formatted = formatUnits(BigInt(amount), decimals);
@@ -129,7 +109,11 @@ export const HistoryDetailsDrawer: React.FC<HistoryDetailsDrawerProps> = ({ spli
                   <div className="badge badge-lg badge-secondary">{getSplitTypeLabel()}</div>
                 </div>
                 <div className="flex items-center gap-2">
-                  <button onClick={handleRepeat} className="btn btn-sm btn-primary gap-2" title="Repeat this split">
+                  <button
+                    onClick={() => handleRepeat(split, isEqual, isErc20, onClose)}
+                    className="btn btn-sm btn-primary gap-2"
+                    title="Repeat this split"
+                  >
                     <Repeat className="w-4 h-4" />
                     Repeat Split
                   </button>

--- a/packages/nextjs/app/history/_components/HistoryDetailsDrawer.tsx
+++ b/packages/nextjs/app/history/_components/HistoryDetailsDrawer.tsx
@@ -19,7 +19,6 @@ interface HistoryDetailsDrawerProps {
 export const HistoryDetailsDrawer: React.FC<HistoryDetailsDrawerProps> = ({ split, isOpen, onClose }) => {
   const targetNetworks = getTargetNetworks();
   const router = useRouter();
-  // ... existing code ...
 
   const splitNetwork = targetNetworks.find(network => network.id == split?.chainId);
   const { copyToClipboard, isCopiedToClipboard } = useCopyToClipboard();

--- a/packages/nextjs/app/history/page.tsx
+++ b/packages/nextjs/app/history/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/router";
+import { useRouter } from "next/navigation";
 import { HistoryCard } from "./_components/HistoryCard";
 import { HistoryDetailsDrawer } from "./_components/HistoryDetailsDrawer";
 import { HistoryFilters } from "./_components/HistoryFilters";
@@ -70,12 +70,10 @@ const HistoryPage = () => {
   const filteredAndSortedHistory = useMemo(() => {
     let filtered = [...history];
 
-    // Filter by type
     if (selectedFilter !== "all") {
       filtered = filtered.filter(item => item.type === selectedFilter);
     }
 
-    // Filter by search term
     if (searchTerm) {
       const search = searchTerm.toLowerCase();
       filtered = filtered.filter(
@@ -87,7 +85,6 @@ const HistoryPage = () => {
       );
     }
 
-    // Sort
     filtered.sort((a, b) => {
       switch (sortBy) {
         case "date-desc":

--- a/packages/nextjs/app/history/page.tsx
+++ b/packages/nextjs/app/history/page.tsx
@@ -62,6 +62,18 @@ const HistoryPage = () => {
     });
     params.append("recipientCount", split.recipientCount.toString());
 
+    if (isEqual) {
+      if (split.amountPerRecipient) {
+        params.append("equalAmount", split.amountPerRecipient);
+      }
+    } else {
+      if (split.amounts && split.amounts.length > 0) {
+        split.amounts.forEach((amount, index) => {
+          params.append(`amount_${index}`, amount);
+        });
+      }
+    }
+
     router.push(`/split?${params.toString()}`);
 
     if (onRepeat) onRepeat();
@@ -127,26 +139,29 @@ const HistoryPage = () => {
 
     const getPageNumbers = () => {
       const pages: (number | string)[] = [];
-      const showEllipsisThreshold = 5;
+      const maxVisible = 5;
 
-      if (totalPages <= showEllipsisThreshold + 2) {
+      if (totalPages <= maxVisible) {
         for (let i = 1; i <= totalPages; i++) {
           pages.push(i);
         }
       } else {
         pages.push(1);
 
-        if (currentPage > 3) {
-          pages.push("...");
+        let start = Math.max(2, currentPage - 1);
+        let end = Math.min(totalPages - 1, currentPage + 1);
+
+        if (currentPage <= 2) {
+          end = 4;
+        } else if (currentPage >= totalPages - 1) {
+          start = totalPages - 3;
         }
 
-        for (let i = Math.max(2, currentPage - 1); i <= Math.min(totalPages - 1, currentPage + 1); i++) {
+        if (start > 2) pages.push("...");
+        for (let i = start; i <= end; i++) {
           pages.push(i);
         }
-
-        if (currentPage < totalPages - 2) {
-          pages.push("...");
-        }
+        if (end < totalPages - 1) pages.push("...");
 
         pages.push(totalPages);
       }
@@ -155,13 +170,8 @@ const HistoryPage = () => {
     };
 
     return (
-      <div className="flex flex-col sm:flex-row items-center justify-between mt-8 pt-6 border-t border-base-300 gap-4 ">
-        <div className="text-sm text-base-content/60 ">
-          Showing {startIndex + 1}-{Math.min(endIndex, filteredAndSortedHistory.length)} of{" "}
-          {filteredAndSortedHistory.length} split{filteredAndSortedHistory.length !== 1 ? "s" : ""}
-        </div>
-
-        <div className="flex items-center gap-2 ">
+      <div className="flex justify-center mt-8">
+        <div className="btn-group">
           <button
             onClick={() => handlePageChange(currentPage - 1)}
             disabled={currentPage === 1}
@@ -171,15 +181,13 @@ const HistoryPage = () => {
             <ChevronLeft className="w-4 h-4" />
           </button>
 
-          <div className="flex gap-1">
+          <div className="flex items-center gap-1 mx-2">
             {getPageNumbers().map((page, index) =>
               typeof page === "number" ? (
                 <button
                   key={index}
                   onClick={() => handlePageChange(page)}
-                  className={`btn btn-sm min-w-[2.5rem] ${
-                    page === currentPage ? "btn-primary" : "btn-ghost hover:btn-secondary"
-                  }`}
+                  className={`btn btn-sm ${currentPage === page ? "btn-primary" : "btn-ghost hover:btn-secondary"}`}
                   aria-label={`Go to page ${page}`}
                 >
                   {page}

--- a/packages/nextjs/app/split/page.tsx
+++ b/packages/nextjs/app/split/page.tsx
@@ -463,7 +463,7 @@ function SplitContent() {
 
     return () => clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [splitMode, equalAmount, recipients, selectedToken]); // Added selectedToken dependency
+  }, [splitMode, equalAmount, recipients, selectedToken]);
 
   useEffect(() => {
     if (splitMode === "UNEQUAL") {
@@ -474,7 +474,7 @@ function SplitContent() {
       return () => clearTimeout(timer);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [recipients.map(r => r.amount).join(","), splitMode, selectedToken]); // Added selectedToken dependency
+  }, [recipients.map(r => r.amount).join(","), splitMode, selectedToken]);
 
   const hasDuplicates = duplicateAddresses.length > 0;
 

--- a/packages/nextjs/app/split/page.tsx
+++ b/packages/nextjs/app/split/page.tsx
@@ -146,15 +146,31 @@ function SplitContent() {
       const count = parseInt(recipientCount);
       const newRecipients: Recipient[] = [];
 
+      const equalAmountParam = searchParams.get("equalAmount");
+      if (mode === "EQUAL" && equalAmountParam) {
+        const decimals = tokenParam === "ETH" ? 18 : parseInt(searchParams.get("tokenDecimals") || "18");
+        const formattedAmount = formatUnits(BigInt(equalAmountParam), decimals);
+        setEqualAmount(formattedAmount);
+      }
+
       for (let i = 0; i < count; i++) {
         const recipientAddress = searchParams.get(`recipient_${i}`);
         if (recipientAddress) {
           const contact = savedContacts.find(c => c.address.toLowerCase() === recipientAddress.toLowerCase());
 
+          let amount = "";
+          if (mode === "UNEQUAL") {
+            const amountParam = searchParams.get(`amount_${i}`);
+            if (amountParam) {
+              const decimals = tokenParam === "ETH" ? 18 : parseInt(searchParams.get("tokenDecimals") || "18");
+              amount = formatUnits(BigInt(amountParam), decimals);
+            }
+          }
+
           newRecipients.push({
             id: Date.now().toString() + i,
             address: recipientAddress,
-            amount: "",
+            amount: amount,
             label: contact?.label || "",
           });
         }

--- a/packages/nextjs/app/split/page.tsx
+++ b/packages/nextjs/app/split/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSearchParams } from "next/navigation";
 import { AssetSelector } from "./_components/AssetSelector";
@@ -84,7 +84,7 @@ const calculatePercentage = (amount: string, total: string, decimals: number): n
   }
 };
 
-export default function Split() {
+function SplitContent() {
   const router = useRouter();
   const chainId = useChainId();
   const searchParams = useSearchParams();
@@ -713,5 +713,19 @@ export default function Split() {
         </motion.div>
       )}
     </div>
+  );
+}
+
+export default function Split() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center min-h-screen">
+          <span className="loading loading-spinner loading-lg"></span>
+        </div>
+      }
+    >
+      <SplitContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Description

This feature was in the old Splitter. It allows you repeat a transaction from your history. 

<img width="442" height="255" alt="Screenshot at Sep 15 20-57-37" src="https://github.com/user-attachments/assets/155a4b9a-2917-4d7d-9b2e-25c79efaae3e" />

Click the Repeat button on a transaction in the history page and it navigates to the /split page populatin the Recipients, Token and Split type