### PR TITLE
Sharable config via URL

### DIFF
--- a/packages/nextjs/app/history/_components/HistoryCard.tsx
+++ b/packages/nextjs/app/history/_components/HistoryCard.tsx
@@ -15,6 +15,7 @@ interface HistoryCardProps {
     split: SplitHistoryItem,
     isEqual: boolean,
     isErc20: boolean,
+    chainId: number,
     onSuccess?: () => void,
     e?: React.MouseEvent,
   ) => void;
@@ -169,7 +170,7 @@ export const HistoryCard: React.FC<HistoryCardProps> = ({ split, onClick, delay 
         <div className="card-actions justify-end">
           <button
             className="btn btn-ghost btn-sm gap-1"
-            onClick={e => handleRepeat(split, isEqual, isErc20, _, e)}
+            onClick={e => handleRepeat(split, isEqual, isErc20, split.chainId, _, e)}
             title="Repeat this split"
           >
             <Repeat className="w-4 h-4" />

--- a/packages/nextjs/app/history/_components/HistoryDetailsDrawer.tsx
+++ b/packages/nextjs/app/history/_components/HistoryDetailsDrawer.tsx
@@ -17,6 +17,7 @@ interface HistoryDetailsDrawerProps {
     split: SplitHistoryItem,
     isEqual: boolean,
     isErc20: boolean,
+    chainId: number,
     onSuccess?: () => void,
     e?: React.MouseEvent,
   ) => void;
@@ -110,7 +111,7 @@ export const HistoryDetailsDrawer: React.FC<HistoryDetailsDrawerProps> = ({ spli
                 </div>
                 <div className="flex items-center gap-2">
                   <button
-                    onClick={() => handleRepeat(split, isEqual, isErc20, onClose)}
+                    onClick={() => handleRepeat(split, isEqual, isErc20, split.chainId, onClose)}
                     className="btn btn-sm btn-primary gap-2"
                     title="Repeat this split"
                   >

--- a/packages/nextjs/app/history/page.tsx
+++ b/packages/nextjs/app/history/page.tsx
@@ -34,6 +34,7 @@ const HistoryPage = () => {
     split: SplitHistoryItem,
     isEqual: boolean,
     isErc20: boolean,
+    chainId: number,
     onRepeat?: () => void,
     e?: React.MouseEvent,
   ) => {
@@ -43,6 +44,7 @@ const HistoryPage = () => {
 
     const params = new URLSearchParams();
 
+    params.append("chainId", chainId.toString());
     params.append("mode", isEqual ? "EQUAL" : "UNEQUAL");
 
     if (isErc20) {

--- a/packages/nextjs/app/split/_components/AssetSelector.tsx
+++ b/packages/nextjs/app/split/_components/AssetSelector.tsx
@@ -174,7 +174,7 @@ export const AssetSelector: React.FC<AssetSelectorProps> = ({
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedToken]);
+  }, [selectedToken, tokenBalance]);
 
   const formatBalance = () => {
     if (!tokenBalance?.balance) return "0";

--- a/packages/nextjs/app/split/_components/ShareConfigButton.tsx
+++ b/packages/nextjs/app/split/_components/ShareConfigButton.tsx
@@ -1,0 +1,215 @@
+import React, { useCallback, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { CheckCircle, Link2, Share2 } from "lucide-react";
+import { parseUnits } from "viem";
+import { useCopyToClipboard } from "~~/hooks/scaffold-eth";
+import { notification } from "~~/utils/scaffold-eth";
+
+interface ShareConfigButtonProps {
+  splitMode: "EQUAL" | "UNEQUAL";
+  recipients: Array<{
+    id: string;
+    address: string;
+    amount: string;
+    label?: string;
+  }>;
+  selectedToken: {
+    address: string;
+    symbol: string;
+    name: string;
+    decimals: number;
+  } | null;
+  equalAmount: string;
+  className?: string;
+}
+
+export const ShareConfigButton: React.FC<ShareConfigButtonProps> = ({
+  splitMode,
+  recipients,
+  selectedToken,
+  equalAmount,
+  className = "",
+}) => {
+  const { copyToClipboard, isCopiedToClipboard } = useCopyToClipboard();
+  const [showShareModal, setShowShareModal] = useState(false);
+  const [generatedUrl, setGeneratedUrl] = useState<string>("");
+
+  const generateShareableUrl = useCallback(() => {
+    const validRecipients = recipients.filter(r => r.address && r.address.trim() !== "");
+
+    if (validRecipients.length === 0) {
+      notification.error("Please add at least one recipient");
+      return null;
+    }
+
+    if (!selectedToken) {
+      notification.error("Please select a token");
+      return null;
+    }
+
+    const params = new URLSearchParams();
+
+    params.append("mode", splitMode);
+
+    if (selectedToken.address === "ETH") {
+      params.append("token", "ETH");
+    } else {
+      params.append("token", selectedToken.address);
+      params.append("tokenSymbol", selectedToken.symbol);
+      params.append("tokenDecimals", selectedToken.decimals.toString());
+    }
+
+    validRecipients.forEach((recipient, index) => {
+      params.append(`recipient_${index}`, recipient.address);
+      if (recipient.label) {
+        params.append(`label_${index}`, recipient.label);
+      }
+    });
+    params.append("recipientCount", validRecipients.length.toString());
+
+    if (splitMode === "EQUAL") {
+      if (equalAmount && equalAmount.trim() !== "") {
+        const decimals = selectedToken.address === "ETH" ? 18 : selectedToken.decimals;
+        try {
+          const rawAmount = parseUnits(equalAmount, decimals);
+          params.append("equalAmount", rawAmount.toString());
+        } catch {}
+      }
+    } else {
+      validRecipients.forEach((recipient, index) => {
+        if (recipient.amount && recipient.amount.trim() !== "") {
+          const decimals = selectedToken.address === "ETH" ? 18 : selectedToken.decimals;
+          try {
+            const rawAmount = parseUnits(recipient.amount, decimals);
+            params.append(`amount_${index}`, rawAmount.toString());
+          } catch {
+            params.append(`amount_${index}`, recipient.amount);
+          }
+        }
+      });
+    }
+
+    const baseUrl = typeof window !== "undefined" ? window.location.origin : "";
+    const shareableUrl = `${baseUrl}/split?${params.toString()}`;
+
+    return shareableUrl;
+  }, [splitMode, recipients, selectedToken, equalAmount]);
+
+  const handleShareClick = () => {
+    const url = generateShareableUrl();
+    if (url) {
+      setGeneratedUrl(url);
+      setShowShareModal(true);
+    }
+  };
+
+  const handleCopyLink = async () => {
+    if (generatedUrl) {
+      await copyToClipboard(generatedUrl);
+      notification.success("Share link copied to clipboard!");
+    }
+  };
+
+  const handleNativeShare = async () => {
+    if (generatedUrl && navigator.share) {
+      try {
+        await navigator.share({
+          title: "Split Configuration",
+          text: `Check out this split configuration for ${selectedToken?.symbol || "tokens"}`,
+          url: generatedUrl,
+        });
+      } catch (error) {
+        console.error("Share failed:", error);
+      }
+    }
+  };
+
+  return (
+    <>
+      <button
+        onClick={handleShareClick}
+        className={`btn btn-md btn-ghost rounded-md gap-2 ${className}`}
+        title="Share split configuration"
+      >
+        <Share2 className="w-4 h-4" />
+        Share Config
+      </button>
+
+      <AnimatePresence>
+        {showShareModal && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
+            onClick={() => setShowShareModal(false)}
+          >
+            <motion.div
+              initial={{ scale: 0.95, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.95, opacity: 0 }}
+              onClick={e => e.stopPropagation()}
+              className="bg-base-100 rounded-2xl shadow-2xl max-w-lg w-full p-6"
+            >
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="text-xl font-bold flex items-center gap-2">
+                  <Link2 className="w-5 h-5" />
+                  Share Split Configuration
+                </h3>
+                <button onClick={() => setShowShareModal(false)} className="btn btn-sm btn-circle btn-ghost">
+                  ✕
+                </button>
+              </div>
+
+              <p className="text-sm text-base-content/70 mb-4">
+                Share this link with others to let them execute the same split configuration:
+              </p>
+
+              <div className="bg-base-200 rounded-xl p-3 mb-4">
+                <div className="flex items-center gap-2">
+                  <input
+                    type="text"
+                    readOnly
+                    value={generatedUrl}
+                    className="input input-sm flex-1 bg-base-200 border-none text-xs"
+                    onClick={e => e.currentTarget.select()}
+                  />
+                </div>
+              </div>
+
+              <div className="flex gap-2">
+                <button onClick={handleCopyLink} className="btn btn-primary flex-1 gap-2">
+                  {isCopiedToClipboard ? (
+                    <>
+                      <CheckCircle className="w-4 h-4" />
+                      Copied!
+                    </>
+                  ) : (
+                    <>
+                      <Link2 className="w-4 h-4" />
+                      Copy Link
+                    </>
+                  )}
+                </button>
+
+                {typeof navigator !== "undefined" && typeof navigator.share === "function" && (
+                  <button onClick={handleNativeShare} className="btn btn-primary  gap-2">
+                    <Share2 className="w-4 h-4" />
+                    Share
+                  </button>
+                )}
+              </div>
+
+              <div className="mt-4 p-3 bg-warning/30 rounded-xl">
+                <p className="text-xs text-warning-content">
+                  <strong>Note:</strong> Recipient will need to connect their wallet and have sufficient funds to
+                  execute this split.
+                </p>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
+  );
+};

--- a/packages/nextjs/app/split/_components/ShareConfigButton.tsx
+++ b/packages/nextjs/app/split/_components/ShareConfigButton.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { CheckCircle, Link2, Share2 } from "lucide-react";
 import { parseUnits } from "viem";
+import { useChainId } from "wagmi";
 import { useCopyToClipboard } from "~~/hooks/scaffold-eth";
 import { notification } from "~~/utils/scaffold-eth";
 
@@ -30,6 +31,7 @@ export const ShareConfigButton: React.FC<ShareConfigButtonProps> = ({
   equalAmount,
   className = "",
 }) => {
+  const chainId = useChainId();
   const { copyToClipboard, isCopiedToClipboard } = useCopyToClipboard();
   const [showShareModal, setShowShareModal] = useState(false);
   const [generatedUrl, setGeneratedUrl] = useState<string>("");
@@ -49,6 +51,7 @@ export const ShareConfigButton: React.FC<ShareConfigButtonProps> = ({
 
     const params = new URLSearchParams();
 
+    params.append("chainId", chainId.toString());
     params.append("mode", splitMode);
 
     if (selectedToken.address === "ETH") {
@@ -93,7 +96,7 @@ export const ShareConfigButton: React.FC<ShareConfigButtonProps> = ({
     const shareableUrl = `${baseUrl}/split?${params.toString()}`;
 
     return shareableUrl;
-  }, [splitMode, recipients, selectedToken, equalAmount]);
+  }, [splitMode, recipients, selectedToken, equalAmount, chainId]);
 
   const handleShareClick = () => {
     const url = generateShareableUrl();
@@ -186,25 +189,31 @@ export const ShareConfigButton: React.FC<ShareConfigButtonProps> = ({
                     </>
                   ) : (
                     <>
-                      <Link2 className="w-4 h-4" />
+                      <svg
+                        className="w-4 h-4"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                        />
+                      </svg>
                       Copy Link
                     </>
                   )}
                 </button>
 
-                {typeof navigator !== "undefined" && typeof navigator.share === "function" && (
-                  <button onClick={handleNativeShare} className="btn btn-primary  gap-2">
+                {typeof navigator.share && (
+                  <button onClick={handleNativeShare} className="btn btn-primary gap-2">
                     <Share2 className="w-4 h-4" />
                     Share
                   </button>
                 )}
-              </div>
-
-              <div className="mt-4 p-3 bg-warning/30 rounded-xl">
-                <p className="text-xs text-warning-content">
-                  <strong>Note:</strong> Recipient will need to connect their wallet and have sufficient funds to
-                  execute this split.
-                </p>
               </div>
             </motion.div>
           </motion.div>

--- a/packages/nextjs/app/split/page.tsx
+++ b/packages/nextjs/app/split/page.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { AssetSelector } from "./_components/AssetSelector";
 import { BulkImportModal } from "./_components/BulkImportModal";
 import { RecipientRow } from "./_components/RecipientRow";
+import { ShareConfigButton } from "./_components/ShareConfigButton";
 import { SplitModeSelector } from "./_components/SplitModeSelector";
 import { TotalAmountDisplay } from "./_components/TotalAmountDisplay";
 import { AnimatePresence, motion } from "framer-motion";
@@ -156,6 +157,8 @@ function SplitContent() {
       for (let i = 0; i < count; i++) {
         const recipientAddress = searchParams.get(`recipient_${i}`);
         if (recipientAddress) {
+          const labelParam = searchParams.get(`label_${i}`);
+
           const contact = savedContacts.find(c => c.address.toLowerCase() === recipientAddress.toLowerCase());
 
           let amount = "";
@@ -171,7 +174,7 @@ function SplitContent() {
             id: Date.now().toString() + i,
             address: recipientAddress,
             amount: amount,
-            label: contact?.label || "",
+            label: labelParam || contact?.label || "",
           });
         }
       }
@@ -497,7 +500,16 @@ function SplitContent() {
   return (
     <div className="max-w-7xl w-full mx-auto py-10 px-4">
       <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
-        <h1 className="text-3xl font-bold mb-8">Split Configuration</h1>
+        <div className="flex items-center justify-between mb-8">
+          <h1 className="text-3xl font-bold">Split Configuration</h1>
+          <ShareConfigButton
+            splitMode={splitMode}
+            recipients={recipients}
+            selectedToken={selectedToken}
+            equalAmount={equalAmount}
+            className="hidden sm:flex"
+          />
+        </div>
 
         <div className="flex md:flex-row flex-col gap-6">
           <div className="md:w-[40%]">
@@ -600,9 +612,16 @@ function SplitContent() {
             </div>
 
             <div className="flex gap-4 mt-6">
+              <ShareConfigButton
+                splitMode={splitMode}
+                recipients={recipients}
+                selectedToken={selectedToken}
+                equalAmount={equalAmount}
+                className="sm:hidden"
+              />
               <button
                 onClick={handleReviewSplit}
-                className="btn btn-md rounded-md w-full btn-primary"
+                className="btn btn-md rounded-md flex-1 btn-primary"
                 disabled={!selectedToken || recipients.length < 2 || hasDuplicates}
               >
                 Review Split

--- a/packages/nextjs/hooks/useTokenBalance.ts
+++ b/packages/nextjs/hooks/useTokenBalance.ts
@@ -5,7 +5,7 @@ import { erc20Abi } from "viem";
 import { useAccount, useBalance, useReadContract, useWaitForTransactionReceipt, useWriteContract } from "wagmi";
 import { wagmiConfig } from "~~/services/web3/wagmiConfig";
 
-export const useTokenBalance = (tokenAddress?: string) => {
+export const useTokenBalance = (chainId: number, tokenAddress?: string) => {
   const { address } = useAccount();
   const { data: deployedContractInfo } = useDeployedContractInfo({ contractName: "ETHSplitter" });
 
@@ -20,6 +20,7 @@ export const useTokenBalance = (tokenAddress?: string) => {
     abi: erc20Abi,
     functionName: "balanceOf",
     args: address ? [address] : undefined,
+    chainId: chainId,
     query: {
       enabled: !!tokenAddress && tokenAddress !== "ETH" && !!address,
     },
@@ -29,6 +30,7 @@ export const useTokenBalance = (tokenAddress?: string) => {
     address: tokenAddress as `0x${string}`,
     abi: erc20Abi,
     functionName: "decimals",
+    chainId: chainId,
     query: {
       enabled: !!tokenAddress && tokenAddress !== "ETH",
     },
@@ -38,6 +40,7 @@ export const useTokenBalance = (tokenAddress?: string) => {
     address: tokenAddress as `0x${string}`,
     abi: erc20Abi,
     functionName: "symbol",
+    chainId: chainId,
     query: {
       enabled: !!tokenAddress && tokenAddress !== "ETH",
     },
@@ -47,6 +50,7 @@ export const useTokenBalance = (tokenAddress?: string) => {
     address: tokenAddress as `0x${string}`,
     abi: erc20Abi,
     functionName: "name",
+    chainId: chainId,
     query: {
       enabled: !!tokenAddress && tokenAddress !== "ETH",
     },
@@ -56,7 +60,6 @@ export const useTokenBalance = (tokenAddress?: string) => {
 
   const { writeContract: approveWrite, isPending: isApproving, data: approveHash } = useWriteContract();
 
-  // Wait for transaction confirmation
   const { isLoading: isConfirming, isSuccess: isConfirmed } = useWaitForTransactionReceipt({
     hash: approveHash,
   });


### PR DESCRIPTION
## Description

This PR introduces support for sharing split configurations via URL on the /split page. A user can now generate a shareable link containing the split details, allowing another user to load the configuration and sign the transaction directly.

Additional Update:

When repeating a split from the history page, the `chainId` of the split is now included in the query. This ensures that the `/split` page initializes on the correct chain.