### PR TITLE
Replaced dropdown in the asset-selector with tags 

### DIFF
--- a/packages/nextjs/app/(home)/_components/AssetSelector.tsx
+++ b/packages/nextjs/app/(home)/_components/AssetSelector.tsx
@@ -242,7 +242,7 @@ export const AssetSelector: React.FC<AssetSelectorProps> = ({
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
             onClick={() => handleTokenSelect(token)}
-            className={`px-3 py-2 rounded-lg  transition-all flex items-center gap-2 ${
+            className={`cursor-pointer px-3 py-2 rounded-lg  transition-all flex items-center gap-2 ${
               selectedToken?.address === token.address ? "bg-primary" : "bg-secondary "
             }`}
           >
@@ -258,7 +258,7 @@ export const AssetSelector: React.FC<AssetSelectorProps> = ({
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
             onClick={() => setShowCustomInput(true)}
-            className="px-3 py-2 rounded-lgtransition-all flex items-center gap-2 bg-secondary"
+            className="cursor-pointer px-3 py-2 rounded-lgtransition-all flex items-center gap-2 bg-secondary"
           >
             <Plus className="w-4 h-4" />
             <span>Other</span>
@@ -282,7 +282,7 @@ export const AssetSelector: React.FC<AssetSelectorProps> = ({
                   setCustomTokenError("");
                   setIsCustomTokenLoading(false);
                 }}
-                className="absolute right-2 top-1/2 transform -translate-y-1/2 p-1 hover:bg-base-300 rounded"
+                className="cursor-pointer absolute right-2 top-1/2 transform -translate-y-1/2 p-1 hover:bg-base-300 rounded"
               >
                 <X className="w-4 h-4" />
               </button>


### PR DESCRIPTION
Refer to Issue #93 

>1. Custom token addition
Old version: Requires two step — Click Split Token option and paste the token address directly.
New version: Requires four steps — open token dropdown → open custom token input → paste address → click add button.

>I think the new version is clearer than the old one, but like you wrote, it needs more steps to do the same. I like the token names as tags from the old version. I think it's better than the dropdown, but the way to use a custom token address is not so clear for a new user.

>One option: like the old version, but not showing the token address input by default. Add a new "Other" tag option. When the user selects this, the token address input is shown. Adds one more step, but I think it's clear how it works.

Now asset selection is done with tags and not a dropdown. And the custom token auto resloves on paste.
Invalid token address and invalid address errors are also displayed


https://github.com/user-attachments/assets/4644e75c-95c9-4d45-8f58-45c2c80725e8



